### PR TITLE
Fix test error in perl v5.10.1

### DIFF
--- a/lib/Mojolicious/Controller/REST.pm
+++ b/lib/Mojolicious/Controller/REST.pm
@@ -30,7 +30,7 @@ sub message {
     my $json = $self->stash('json');
 
     if ( defined( $json->{messages} ) ) {
-        push( $json->{messages}, { text => $message, severity => $severity } );
+        push( @{$json->{messages}}, { text => $message, severity => $severity } );
     }
     else {
         $json->{messages} = [ { text => $message, severity => $severity } ];


### PR DESCRIPTION
Error occured when used in perl version 5.10.1, because 5.10 doesnot support `ArrayRef` in `push` arguments.